### PR TITLE
Fixing a minor typo in the next-steps docs

### DIFF
--- a/src/assets/web/next-steps.md
+++ b/src/assets/web/next-steps.md
@@ -40,7 +40,7 @@ In the `<head>` section of your HTML, add the following code:
 
 ## 5. Add a service worker registration snippet to your HTML
 
-Now that you've uplaoded your service worker file, your HTML page should register your service worker.
+Now that you've uploaded your service worker file, your HTML page should register your service worker.
 
 In the `<head>` section of your HTML, add the following code:
 


### PR DESCRIPTION
I was going through this documentation today and realized that there was a typo in the word `uplaoded`.
This is a simple PR to address this typo.